### PR TITLE
Skeleton - Add Mock Screens for Winning or Losing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # Godot 4+ specific ignores
 .godot/
+
+# Already imported assets
+assets/data/enable1.txt
+assets/fonts/Roboto/

--- a/src/developer_only_navigation/DeveloperOnlyNavigation.gd
+++ b/src/developer_only_navigation/DeveloperOnlyNavigation.gd
@@ -1,0 +1,7 @@
+extends Control
+
+func _on_win_button_pressed():
+	get_tree().change_scene_to_file("res://src/game_over_win/GameOverWin.tscn")
+
+func _on_lose_button_pressed():
+	get_tree().change_scene_to_file("res://src/game_over_lose/GameOverLose.tscn")

--- a/src/developer_only_navigation/DeveloperOnlyNavigation.tscn
+++ b/src/developer_only_navigation/DeveloperOnlyNavigation.tscn
@@ -1,0 +1,34 @@
+[gd_scene load_steps=3 format=3 uid="uid://bv02y4o3plw5q"]
+
+[ext_resource type="Script" path="res://src/developer_only_navigation/DeveloperOnlyNavigation.gd" id="1_hdxli"]
+[ext_resource type="Theme" uid="uid://c1rbyyhtqrqqt" path="res://assets/fonts/normal_font_theme.tres" id="1_kdrps"]
+
+[node name="DeveloperOnlyNavigation" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_kdrps")
+script = ExtResource("1_hdxli")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 0
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="Label" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Skip to the end?"
+
+[node name="WinButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "Victory 🙂"
+
+[node name="LoseButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "Defeat 🩹"
+
+[connection signal="pressed" from="VBoxContainer/WinButton" to="." method="_on_win_button_pressed"]
+[connection signal="pressed" from="VBoxContainer/LoseButton" to="." method="_on_lose_button_pressed"]

--- a/src/game_over_lose/GameOverLose.tscn
+++ b/src/game_over_lose/GameOverLose.tscn
@@ -1,0 +1,32 @@
+[gd_scene load_steps=4 format=3 uid="uid://bxf0jw3num74o"]
+
+[ext_resource type="Theme" uid="uid://c76ovc86ky5qb" path="res://assets/fonts/start_menu_title_font_theme.tres" id="1_1vpuw"]
+[ext_resource type="PackedScene" uid="uid://hybadqqg72n5" path="res://src/back_to_start_menu_button/BackToStartMenuButton.tscn" id="1_wyp61"]
+[ext_resource type="PackedScene" uid="uid://eanx8lpdpjr4" path="res://src/game_over_statistics/GameOverStatistics.tscn" id="2_6s5qo"]
+
+[node name="GameOverLose" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Announcement" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -322.5
+offset_right = 322.5
+offset_bottom = 85.0
+grow_horizontal = 2
+theme = ExtResource("1_1vpuw")
+text = "Too Bad! Try Again?"
+
+[node name="GameOverStatistics" parent="." instance=ExtResource("2_6s5qo")]
+layout_mode = 1
+
+[node name="BackToStartMenuButton" parent="." instance=ExtResource("1_wyp61")]
+layout_direction = 0
+layout_mode = 1

--- a/src/game_over_statistics/GameOverStatistics.gd
+++ b/src/game_over_statistics/GameOverStatistics.gd
@@ -1,0 +1,18 @@
+extends Control
+
+@onready var row_heroes_summoned_count = $Rows/HeroesSummoned/Count
+@onready var row_monsters_slain_count = $Rows/MonstersSlain/Count
+@onready var row_peasants_constripted_count = $Rows/PeasantsConscripted/Count
+
+func _ready():
+	_init_statistics_rows_counts()
+
+func _init_statistics_rows_counts() -> void:
+	var mock_heroes_summoned = 33
+	row_heroes_summoned_count.text = str(mock_heroes_summoned)
+
+	var mock_monsters_slain = 9876
+	row_monsters_slain_count.text = str(mock_monsters_slain)
+
+	var mock_peasants_constripted = 777
+	row_peasants_constripted_count.text = str(mock_peasants_constripted)

--- a/src/game_over_statistics/GameOverStatistics.tscn
+++ b/src/game_over_statistics/GameOverStatistics.tscn
@@ -1,0 +1,86 @@
+[gd_scene load_steps=3 format=3 uid="uid://eanx8lpdpjr4"]
+
+[ext_resource type="Theme" uid="uid://c1rbyyhtqrqqt" path="res://assets/fonts/normal_font_theme.tres" id="1_o5oao"]
+[ext_resource type="Script" path="res://src/game_over_statistics/GameOverStatistics.gd" id="1_sxq5r"]
+
+[node name="GameOverStatistics" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_o5oao")
+script = ExtResource("1_sxq5r")
+
+[node name="Rows" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -97.5
+offset_top = -25.0
+offset_right = 97.5
+offset_bottom = 25.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 8
+
+[node name="HeroesSummoned" type="HBoxContainer" parent="Rows"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Rows/HeroesSummoned"]
+layout_mode = 2
+text = "Heroes Summoned"
+
+[node name="HSpacing" type="Control" parent="Rows/HeroesSummoned"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Multiplication" type="Label" parent="Rows/HeroesSummoned"]
+layout_mode = 2
+text = "X"
+
+[node name="Count" type="Label" parent="Rows/HeroesSummoned"]
+layout_mode = 2
+text = "0"
+
+[node name="PeasantsConscripted" type="HBoxContainer" parent="Rows"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Rows/PeasantsConscripted"]
+layout_mode = 2
+text = "Peasants Conscripted"
+
+[node name="HSpacing" type="Control" parent="Rows/PeasantsConscripted"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Multiplication" type="Label" parent="Rows/PeasantsConscripted"]
+layout_mode = 2
+text = "X"
+
+[node name="Count" type="Label" parent="Rows/PeasantsConscripted"]
+layout_mode = 2
+text = "0"
+
+[node name="MonstersSlain" type="HBoxContainer" parent="Rows"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Rows/MonstersSlain"]
+layout_mode = 2
+text = "Monsters Slain"
+
+[node name="HSpacing" type="Control" parent="Rows/MonstersSlain"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Multiplication" type="Label" parent="Rows/MonstersSlain"]
+layout_mode = 2
+text = "X"
+
+[node name="Count" type="Label" parent="Rows/MonstersSlain"]
+layout_mode = 2
+text = "0"

--- a/src/game_over_win/GameOverWin.tscn
+++ b/src/game_over_win/GameOverWin.tscn
@@ -1,0 +1,33 @@
+[gd_scene load_steps=4 format=3 uid="uid://bs11mic41td2i"]
+
+[ext_resource type="Theme" uid="uid://c76ovc86ky5qb" path="res://assets/fonts/start_menu_title_font_theme.tres" id="1_35pj7"]
+[ext_resource type="PackedScene" uid="uid://hybadqqg72n5" path="res://src/back_to_start_menu_button/BackToStartMenuButton.tscn" id="1_ppj6s"]
+[ext_resource type="PackedScene" uid="uid://eanx8lpdpjr4" path="res://src/game_over_statistics/GameOverStatistics.tscn" id="1_u87r6"]
+
+[node name="GameOverWin" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Announcement" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -125.5
+offset_right = 125.5
+offset_bottom = 85.0
+grow_horizontal = 2
+theme = ExtResource("1_35pj7")
+text = "Victory!"
+horizontal_alignment = 1
+
+[node name="GameOverStatistics" parent="." instance=ExtResource("1_u87r6")]
+layout_mode = 1
+
+[node name="BackToStartMenuButton" parent="." instance=ExtResource("1_ppj6s")]
+layout_direction = 0
+layout_mode = 1

--- a/src/gameplay/Gameplay.tscn
+++ b/src/gameplay/Gameplay.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://bcxndlanc4xko"]
+[gd_scene load_steps=4 format=3 uid="uid://bcxndlanc4xko"]
 
 [ext_resource type="Script" path="res://src/gameplay/Gameplay.gd" id="1_fe8ca"]
 [ext_resource type="PackedScene" uid="uid://hybadqqg72n5" path="res://src/back_to_start_menu_button/BackToStartMenuButton.tscn" id="2_66iqr"]
+[ext_resource type="PackedScene" uid="uid://bv02y4o3plw5q" path="res://src/developer_only_navigation/DeveloperOnlyNavigation.tscn" id="3_6xc6h"]
 
 [node name="Gameplay" type="Control"]
 layout_mode = 3
@@ -11,6 +12,9 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_fe8ca")
+
+[node name="DeveloperOnlyNavigation" parent="." instance=ExtResource("3_6xc6h")]
+layout_mode = 1
 
 [node name="BackToStartMenuButton" parent="." instance=ExtResource("2_66iqr")]
 layout_direction = 0


### PR DESCRIPTION
Add temporary buttons to win or lose the game, to lead to the game over screens with mock data counts.

## Screenshots

![2024-04-13_pr-skip-to-end](https://github.com/SamBumgardner/alphabet-heroes/assets/11843918/3ec8849e-2de6-46d3-b076-b5b0fd8a858d)
_**Screenshot 1:** Gameplay screen with developer buttons to cheat to victory or defeat._

![2024-04-13_pr-victory](https://github.com/SamBumgardner/alphabet-heroes/assets/11843918/95a75b63-818f-4dda-b862-bf29c95a4442)
_**Screenshot 2:** Victory screen with mock statistics._

![2024-04-13_pr-defeat](https://github.com/SamBumgardner/alphabet-heroes/assets/11843918/a4db97e8-d6a2-49b9-8628-7b13ecf859c7)
_**Screenshot 3:** Defeat screen with mock statistics._