### PR TITLE
Gameplay - Add Summon New Heroes Button and Hook It Up to Tray

### DIFF
--- a/src/developer_only_navigation/DeveloperOnlyNavigation.tscn
+++ b/src/developer_only_navigation/DeveloperOnlyNavigation.tscn
@@ -5,11 +5,7 @@
 
 [node name="DeveloperOnlyNavigation" type="Control"]
 layout_mode = 3
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
+anchors_preset = 0
 theme = ExtResource("1_kdrps")
 script = ExtResource("1_hdxli")
 

--- a/src/gameplay/Gameplay.gd
+++ b/src/gameplay/Gameplay.gd
@@ -4,6 +4,3 @@ extends Control
 
 func _ready():
 	database.reset_values()
-
-func _process(delta):
-	pass

--- a/src/gameplay/Gameplay.tscn
+++ b/src/gameplay/Gameplay.tscn
@@ -1,10 +1,14 @@
-[gd_scene load_steps=6 format=3 uid="uid://bcxndlanc4xko"]
+[gd_scene load_steps=10 format=3 uid="uid://bcxndlanc4xko"]
 
 [ext_resource type="Script" path="res://src/gameplay/Gameplay.gd" id="1_fe8ca"]
 [ext_resource type="PackedScene" uid="uid://hybadqqg72n5" path="res://src/back_to_start_menu_button/BackToStartMenuButton.tscn" id="2_66iqr"]
 [ext_resource type="PackedScene" uid="uid://bv02y4o3plw5q" path="res://src/developer_only_navigation/DeveloperOnlyNavigation.tscn" id="3_6xc6h"]
 [ext_resource type="PackedScene" uid="uid://oyd68ql208nv" path="res://src/tray_of_heroes/TrayOfHeroes.tscn" id="4_vlgye"]
 [ext_resource type="Theme" uid="uid://c1rbyyhtqrqqt" path="res://assets/fonts/normal_font_theme.tres" id="5_hjbl1"]
+[ext_resource type="Script" path="res://src/TextController.gd" id="6_dfxbv"]
+[ext_resource type="Script" path="res://src/heroes/PartyController.gd" id="7_vb18x"]
+[ext_resource type="Script" path="res://src/heroes/HeroRepository.gd" id="8_uko4w"]
+[ext_resource type="Script" path="res://demos/text-input/SimpleTextVisualizer.gd" id="9_tevq5"]
 
 [node name="Gameplay" type="Control"]
 layout_mode = 3
@@ -40,3 +44,28 @@ grow_vertical = 2
 theme = ExtResource("5_hjbl1")
 text = "Summon New
 Heroes"
+
+[node name="TextController" type="Node" parent="."]
+script = ExtResource("6_dfxbv")
+max_letters = 10
+
+[node name="PartyController" type="Node" parent="."]
+script = ExtResource("7_vb18x")
+
+[node name="HeroRepository" type="Node" parent="."]
+script = ExtResource("8_uko4w")
+
+[node name="SimpleTextVisualizer" type="Label" parent="."]
+layout_mode = 0
+offset_left = 328.0
+offset_top = 160.0
+offset_right = 378.0
+offset_bottom = 183.0
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 5
+theme_override_font_sizes/font_size = 48
+script = ExtResource("9_tevq5")
+
+[connection signal="pressed" from="SummonNewHeroesButton" to="HeroRepository" method="generate_heroes"]
+[connection signal="hero_repository_contents_changed" from="HeroRepository" to="TrayOfHeroes" method="_on_hero_repository_hero_repository_contents_changed"]

--- a/src/gameplay/Gameplay.tscn
+++ b/src/gameplay/Gameplay.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=5 format=3 uid="uid://bcxndlanc4xko"]
+[gd_scene load_steps=6 format=3 uid="uid://bcxndlanc4xko"]
 
 [ext_resource type="Script" path="res://src/gameplay/Gameplay.gd" id="1_fe8ca"]
 [ext_resource type="PackedScene" uid="uid://hybadqqg72n5" path="res://src/back_to_start_menu_button/BackToStartMenuButton.tscn" id="2_66iqr"]
 [ext_resource type="PackedScene" uid="uid://bv02y4o3plw5q" path="res://src/developer_only_navigation/DeveloperOnlyNavigation.tscn" id="3_6xc6h"]
 [ext_resource type="PackedScene" uid="uid://oyd68ql208nv" path="res://src/tray_of_heroes/TrayOfHeroes.tscn" id="4_vlgye"]
+[ext_resource type="Theme" uid="uid://c1rbyyhtqrqqt" path="res://assets/fonts/normal_font_theme.tres" id="5_hjbl1"]
 
 [node name="Gameplay" type="Control"]
 layout_mode = 3
@@ -23,3 +24,19 @@ layout_mode = 1
 [node name="BackToStartMenuButton" parent="." instance=ExtResource("2_66iqr")]
 layout_direction = 0
 layout_mode = 1
+
+[node name="SummonNewHeroesButton" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 6
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_left = -8.0
+offset_top = -4.0
+offset_bottom = 4.0
+grow_horizontal = 0
+grow_vertical = 2
+theme = ExtResource("5_hjbl1")
+text = "Summon New
+Heroes"

--- a/src/gameplay/Gameplay.tscn
+++ b/src/gameplay/Gameplay.tscn
@@ -21,9 +21,20 @@ script = ExtResource("1_fe8ca")
 
 [node name="TrayOfHeroes" parent="." instance=ExtResource("4_vlgye")]
 layout_mode = 1
+anchors_preset = 12
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 0
 
 [node name="DeveloperOnlyNavigation" parent="." instance=ExtResource("3_6xc6h")]
 layout_mode = 1
+anchors_preset = 0
+anchor_right = 0.0
+anchor_bottom = 0.0
+grow_horizontal = 1
+grow_vertical = 1
 
 [node name="BackToStartMenuButton" parent="." instance=ExtResource("2_66iqr")]
 layout_direction = 0

--- a/src/gameplay/Gameplay.tscn
+++ b/src/gameplay/Gameplay.tscn
@@ -30,11 +30,6 @@ grow_vertical = 0
 
 [node name="DeveloperOnlyNavigation" parent="." instance=ExtResource("3_6xc6h")]
 layout_mode = 1
-anchors_preset = 0
-anchor_right = 0.0
-anchor_bottom = 0.0
-grow_horizontal = 1
-grow_vertical = 1
 
 [node name="BackToStartMenuButton" parent="." instance=ExtResource("2_66iqr")]
 layout_direction = 0
@@ -79,4 +74,6 @@ theme_override_font_sizes/font_size = 48
 script = ExtResource("9_tevq5")
 
 [connection signal="pressed" from="SummonNewHeroesButton" to="HeroRepository" method="generate_heroes"]
+[connection signal="word_changed" from="TextController" to="SimpleTextVisualizer" method="_on_word_changed"]
+[connection signal="word_consumed" from="TextController" to="HeroRepository" method="remove"]
 [connection signal="hero_repository_contents_changed" from="HeroRepository" to="TrayOfHeroes" method="_on_hero_repository_hero_repository_contents_changed"]

--- a/src/gameplay/Gameplay.tscn
+++ b/src/gameplay/Gameplay.tscn
@@ -47,6 +47,7 @@ offset_top = -4.0
 offset_bottom = 4.0
 grow_horizontal = 0
 grow_vertical = 2
+focus_mode = 0
 theme = ExtResource("5_hjbl1")
 text = "Summon New
 Heroes"

--- a/src/hero_panel/HeroPanel.gd
+++ b/src/hero_panel/HeroPanel.gd
@@ -5,10 +5,10 @@ extends Control
 @export var portrait_to_display : CompressedTexture2D
 
 @onready var label_of_job : Label = (
-	$PanelContainer/MarginContainer/HBoxContainer/HeroStatistics/LabelOfJob
+	$MarginContainer/HBoxContainer/HeroStatistics/LabelOfJob
 )
 @onready var hero_portrait : TextureRect = (
-	$PanelContainer/MarginContainer/HBoxContainer/HeroPortrait
+	$MarginContainer/HBoxContainer/HeroPortrait
 )
 
 func _ready():

--- a/src/hero_panel/HeroPanel.gd
+++ b/src/hero_panel/HeroPanel.gd
@@ -10,6 +10,9 @@ extends Control
 @onready var hero_portrait : TextureRect = (
 	$MarginContainer/HBoxContainer/HeroPortrait
 )
+@onready var heroes_as_letter_names : RichTextLabel = (
+	$MarginContainer/HBoxContainer/HeroStatistics/HeroesAsLetterNames
+)
 
 func _ready():
 	var hero_class_name : String = Hero.Job.keys()[job_to_display]
@@ -17,6 +20,11 @@ func _ready():
 	label_of_job.text = _build_hero_class_name_label(hero_class_name)
 
 	hero_portrait.texture = portrait_to_display
+
+	heroes_as_letter_names.text = ""
+
+func set_heroes_as_letter_names_text(letter_names: String) -> void:
+	heroes_as_letter_names.text = letter_names
 
 func _build_hero_class_name_label(hero_class_name: String) -> String:
 	return (

--- a/src/hero_panel/HeroPanel.tscn
+++ b/src/hero_panel/HeroPanel.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=3 uid="uid://bq3nvxvnxfek4"]
+[gd_scene load_steps=5 format=3 uid="uid://bq3nvxvnxfek4"]
 
 [ext_resource type="Script" path="res://src/hero_panel/HeroPanel.gd" id="1_0kmgj"]
 [ext_resource type="Theme" uid="uid://c1rbyyhtqrqqt" path="res://assets/fonts/normal_font_theme.tres" id="1_lua0a"]
 [ext_resource type="Texture2D" uid="uid://bomytq1jpagf4" path="res://assets/art/Warrior_128x128.png" id="2_77xvi"]
+[ext_resource type="Script" path="res://demos/party-controller/HeroRepositoryVisualizer.gd" id="3_ft478"]
 
 [node name="HeroPanel" type="Control"]
 layout_mode = 3
@@ -42,3 +43,24 @@ layout_mode = 2
 [node name="LabelOfJob" type="Label" parent="PanelContainer/MarginContainer/HBoxContainer/HeroStatistics"]
 layout_mode = 2
 text = "Peasant:"
+
+[node name="HeroRepositoryVisualizerWarrior" type="Label" parent="PanelContainer/MarginContainer/HBoxContainer/HeroStatistics"]
+visible = false
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 5
+theme_override_font_sizes/font_size = 20
+script = ExtResource("3_ft478")
+
+[node name="ItemList" type="ItemList" parent="PanelContainer/MarginContainer/HBoxContainer/HeroStatistics"]
+visible = false
+layout_mode = 2
+auto_height = true
+item_count = 4
+max_columns = 3
+same_column_width = true
+item_0/text = "A"
+item_1/text = "B"
+item_2/text = "C"
+item_3/text = "D"

--- a/src/hero_panel/HeroPanel.tscn
+++ b/src/hero_panel/HeroPanel.tscn
@@ -35,3 +35,8 @@ layout_mode = 2
 [node name="LabelOfJob" type="Label" parent="MarginContainer/HBoxContainer/HeroStatistics"]
 layout_mode = 2
 text = "Peasant:"
+
+[node name="HeroesAsLetterNames" type="RichTextLabel" parent="MarginContainer/HBoxContainer/HeroStatistics"]
+layout_mode = 2
+size_flags_vertical = 3
+text = "A, B, C, D"

--- a/src/hero_panel/HeroPanel.tscn
+++ b/src/hero_panel/HeroPanel.tscn
@@ -31,6 +31,7 @@ layout_mode = 2
 
 [node name="HeroStatistics" type="VBoxContainer" parent="MarginContainer/HBoxContainer"]
 layout_mode = 2
+size_flags_horizontal = 3
 
 [node name="LabelOfJob" type="Label" parent="MarginContainer/HBoxContainer/HeroStatistics"]
 layout_mode = 2

--- a/src/hero_panel/HeroPanel.tscn
+++ b/src/hero_panel/HeroPanel.tscn
@@ -1,66 +1,41 @@
-[gd_scene load_steps=5 format=3 uid="uid://bq3nvxvnxfek4"]
+[gd_scene load_steps=4 format=3 uid="uid://bq3nvxvnxfek4"]
 
 [ext_resource type="Script" path="res://src/hero_panel/HeroPanel.gd" id="1_0kmgj"]
 [ext_resource type="Theme" uid="uid://c1rbyyhtqrqqt" path="res://assets/fonts/normal_font_theme.tres" id="1_lua0a"]
 [ext_resource type="Texture2D" uid="uid://bomytq1jpagf4" path="res://assets/art/Warrior_128x128.png" id="2_77xvi"]
-[ext_resource type="Script" path="res://demos/party-controller/HeroRepositoryVisualizer.gd" id="3_ft478"]
 
-[node name="HeroPanel" type="Control"]
-layout_mode = 3
-anchors_preset = 0
+[node name="HeroPanelContainer" type="PanelContainer"]
 theme = ExtResource("1_lua0a")
 script = ExtResource("1_0kmgj")
 portrait_to_display = ExtResource("2_77xvi")
 
-[node name="PanelContainer" type="PanelContainer" parent="."]
-layout_mode = 0
-offset_right = 40.0
-offset_bottom = 40.0
-
-[node name="Panel" type="Panel" parent="PanelContainer"]
+[node name="Panel" type="Panel" parent="."]
 layout_mode = 2
 
-[node name="MarginContainer" type="MarginContainer" parent="PanelContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 2
 theme_override_constants/margin_left = 4
 theme_override_constants/margin_right = 4
 
-[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/MarginContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer"]
 layout_mode = 2
 
-[node name="HeroPortrait" type="TextureRect" parent="PanelContainer/MarginContainer/HBoxContainer"]
+[node name="HeroPortrait" type="TextureRect" parent="MarginContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 8
 texture = ExtResource("2_77xvi")
 stretch_mode = 2
 
-[node name="VSeparator" type="VSeparator" parent="PanelContainer/MarginContainer/HBoxContainer"]
+[node name="VSeparator" type="VSeparator" parent="MarginContainer/HBoxContainer"]
 layout_mode = 2
 
-[node name="HeroStatistics" type="VBoxContainer" parent="PanelContainer/MarginContainer/HBoxContainer"]
+[node name="HeroStatistics" type="VBoxContainer" parent="MarginContainer/HBoxContainer"]
 layout_mode = 2
 
-[node name="LabelOfJob" type="Label" parent="PanelContainer/MarginContainer/HBoxContainer/HeroStatistics"]
+[node name="LabelOfJob" type="Label" parent="MarginContainer/HBoxContainer/HeroStatistics"]
 layout_mode = 2
 text = "Peasant:"
 
-[node name="HeroRepositoryVisualizerWarrior" type="Label" parent="PanelContainer/MarginContainer/HBoxContainer/HeroStatistics"]
-visible = false
+[node name="HSpacing" type="Control" parent="MarginContainer/HBoxContainer"]
 layout_mode = 2
-theme_override_colors/font_color = Color(1, 1, 1, 1)
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 5
-theme_override_font_sizes/font_size = 20
-script = ExtResource("3_ft478")
-
-[node name="ItemList" type="ItemList" parent="PanelContainer/MarginContainer/HBoxContainer/HeroStatistics"]
-visible = false
-layout_mode = 2
-auto_height = true
-item_count = 4
-max_columns = 3
-same_column_width = true
-item_0/text = "A"
-item_1/text = "B"
-item_2/text = "C"
-item_3/text = "D"
+size_flags_horizontal = 3

--- a/src/hero_panel/HeroPanel.tscn
+++ b/src/hero_panel/HeroPanel.tscn
@@ -35,7 +35,3 @@ layout_mode = 2
 [node name="LabelOfJob" type="Label" parent="MarginContainer/HBoxContainer/HeroStatistics"]
 layout_mode = 2
 text = "Peasant:"
-
-[node name="HSpacing" type="Control" parent="MarginContainer/HBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 3

--- a/src/tray_of_heroes/TrayOfHeroes.gd
+++ b/src/tray_of_heroes/TrayOfHeroes.gd
@@ -1,5 +1,7 @@
 extends Control
 
+@onready var columns_of_panels = $MarginContainer/ColumnsOfPanels
+
 var hero_jobs_to_display = [
 	Hero.Job.WARRIOR,
 	Hero.Job.KNIGHT,
@@ -27,4 +29,17 @@ func _on_hero_repository_hero_repository_contents_changed(current_repository):
 			hero_job,
 			" has heroes: ",
 			debug_text
+		)
+
+	var panel_list = columns_of_panels.get_children()
+
+	for panel in panel_list:
+		var heroes_as_letter_list = current_repository[
+			panel.job_to_display
+		].keys()
+		print(
+			"TrayOfHeroes heard that column ",
+			panel,
+			" has heroes: ",
+			heroes_as_letter_list
 		)

--- a/src/tray_of_heroes/TrayOfHeroes.gd
+++ b/src/tray_of_heroes/TrayOfHeroes.gd
@@ -2,44 +2,48 @@ extends Control
 
 @onready var columns_of_panels = $MarginContainer/ColumnsOfPanels
 
-var hero_jobs_to_display = [
+var dummy_value_to_initialize_empty_display_of_heroes : Array = [
+	{},
+	{},
+	{},
+	{}
+]
+
+var hero_jobs_to_display : Array = [
 	Hero.Job.WARRIOR,
 	Hero.Job.KNIGHT,
 	Hero.Job.MAGE,
 	Hero.Job.PRIEST
 ]
 
-var dummy_value_to_initialize_empty_display_of_heroes = [{}, {}, {}, {}]
-
 func _ready():
+	if (
+		dummy_value_to_initialize_empty_display_of_heroes.size()
+		!= hero_jobs_to_display.size()
+	):
+		push_warning("TrayOfHeroes has mismatching job counts on startup")
+
 	_on_hero_repository_hero_repository_contents_changed(
 		dummy_value_to_initialize_empty_display_of_heroes
 	)
 
+# Combine an array of strings into a comma-space delimited string.
+func _join(string_array: Array) -> String:
+	var joined_text = ""
+
+	for string_item in string_array:
+		joined_text += "%s, " % string_item
+
+	# Remove trailing comma, if any.
+	if joined_text != "":
+		joined_text = joined_text.left(-2)
+
+	return joined_text
+
 func _on_hero_repository_hero_repository_contents_changed(current_repository):
-	for hero_job in hero_jobs_to_display:
-		var heroes_as_letter_list = current_repository[hero_job].keys()
-
-		# List single-letter names of heroes, comma-delimited.
-		var debug_text = ""
-		for hero_as_letter in heroes_as_letter_list:
-			debug_text += "%s, " % hero_as_letter
-		print(
-			"TrayOfHeroes heard that column ",
-			hero_job,
-			" has heroes: ",
-			debug_text
-		)
-
-	var panel_list = columns_of_panels.get_children()
-
-	for panel in panel_list:
+	for panel in columns_of_panels.get_children():
 		var heroes_as_letter_list = current_repository[
 			panel.job_to_display
 		].keys()
-		print(
-			"TrayOfHeroes heard that column ",
-			panel,
-			" has heroes: ",
-			heroes_as_letter_list
-		)
+
+		panel.set_heroes_as_letter_names_text(_join(heroes_as_letter_list))

--- a/src/tray_of_heroes/TrayOfHeroes.gd
+++ b/src/tray_of_heroes/TrayOfHeroes.gd
@@ -1,0 +1,30 @@
+extends Control
+
+var hero_jobs_to_display = [
+	Hero.Job.WARRIOR,
+	Hero.Job.KNIGHT,
+	Hero.Job.MAGE,
+	Hero.Job.PRIEST
+]
+
+var dummy_value_to_initialize_empty_display_of_heroes = [{}, {}, {}, {}]
+
+func _ready():
+	_on_hero_repository_hero_repository_contents_changed(
+		dummy_value_to_initialize_empty_display_of_heroes
+	)
+
+func _on_hero_repository_hero_repository_contents_changed(current_repository):
+	for hero_job in hero_jobs_to_display:
+		var heroes_as_letter_list = current_repository[hero_job].keys()
+
+		# List single-letter names of heroes, comma-delimited.
+		var debug_text = ""
+		for hero_as_letter in heroes_as_letter_list:
+			debug_text += "%s, " % hero_as_letter
+		print(
+			"TrayOfHeroes heard that column ",
+			hero_job,
+			" has heroes: ",
+			debug_text
+		)

--- a/src/tray_of_heroes/TrayOfHeroes.tscn
+++ b/src/tray_of_heroes/TrayOfHeroes.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=6 format=3 uid="uid://oyd68ql208nv"]
+[gd_scene load_steps=7 format=3 uid="uid://oyd68ql208nv"]
 
 [ext_resource type="Theme" uid="uid://c1rbyyhtqrqqt" path="res://assets/fonts/normal_font_theme.tres" id="1_vu46n"]
+[ext_resource type="Script" path="res://src/tray_of_heroes/TrayOfHeroes.gd" id="2_0a3gd"]
 [ext_resource type="Texture2D" uid="uid://s53eonie54i8" path="res://assets/art/Mage_128x128.png" id="3_kjwg4"]
 [ext_resource type="Texture2D" uid="uid://skraovlbkvh8" path="res://assets/art/Knight_128x128.png" id="3_uyr2j"]
 [ext_resource type="Texture2D" uid="uid://4drt8tdciyox" path="res://assets/art/Priest_128x128.png" id="5_5lri7"]
@@ -14,6 +15,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("1_vu46n")
+script = ExtResource("2_0a3gd")
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 1

--- a/src/tray_of_heroes/TrayOfHeroes.tscn
+++ b/src/tray_of_heroes/TrayOfHeroes.tscn
@@ -22,7 +22,6 @@ anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_top = -136.0
-offset_bottom = -128.0
 grow_horizontal = 2
 grow_vertical = 0
 theme_override_constants/margin_left = 4

--- a/src/tray_of_heroes/TrayOfHeroes.tscn
+++ b/src/tray_of_heroes/TrayOfHeroes.tscn
@@ -9,11 +9,7 @@
 
 [node name="TrayOfHeroes" type="Control"]
 layout_mode = 3
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
+anchors_preset = 0
 theme = ExtResource("1_vu46n")
 script = ExtResource("2_0a3gd")
 


### PR DESCRIPTION
Add a Summon New Heroes button on the right side of the gameplay screen, that summons heroes which are displayed in the tray.

## Screenshots

![2024-04-13_pr-tray-with-summoning](https://github.com/SamBumgardner/alphabet-heroes/assets/11843918/86276c42-ffda-4fbb-ab6e-b783f4958ad2)
_**Screenshot 1:** Gameplay screen after summoning maximum heroes, yet before making the button not able to focus._

![2024-04-13_pr-tray-with-summoning-and-scroll-bar](https://github.com/SamBumgardner/alphabet-heroes/assets/11843918/63c62e2f-eec9-4599-bca4-c7d168f758ef)
_**Screenshot 2:** Gameplay screen after summoning maximum heroes on a narrow window so a scrollbar shows up for the Priest hero job, yet before making the button not able to focus._