### PR TITLE
Gameplay - Allow Escape While Traveling AND Fix SFX to Not Override

### DIFF
--- a/src/audio_manager/AudioManager.tscn
+++ b/src/audio_manager/AudioManager.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=3 uid="uid://f34u2l70v1q7"]
+[gd_scene load_steps=7 format=3 uid="uid://f34u2l70v1q7"]
 
 [ext_resource type="Script" path="res://src/audio_manager/AudioManager.gd" id="1_abr2a"]
 [ext_resource type="AudioStream" uid="uid://dfkmsfggjrc3x" path="res://assets/audio/001_music_loop.ogg" id="2_gdr37"]
@@ -6,7 +6,6 @@
 [ext_resource type="AudioStream" uid="uid://mu8msxrjpfry" path="res://assets/audio/102_sfx_select.wav" id="5_nxxot"]
 [ext_resource type="AudioStream" uid="uid://crqucowfla56x" path="res://assets/audio/103_sfx_rustle.wav" id="5_ycj67"]
 [ext_resource type="AudioStream" uid="uid://bdd2svy02l4i1" path="res://assets/audio/101_sfx_button.wav" id="6_5yvfi"]
-[ext_resource type="AudioStream" uid="uid://cbk3krfow3chy" path="res://assets/audio/104_sfx_combat_player_windup.wav" id="7_g0wlx"]
 
 [node name="AudioManager" type="Node"]
 script = ExtResource("1_abr2a")
@@ -15,4 +14,3 @@ background_music_default = ExtResource("2_gdr37")
 sfx_button_click = ExtResource("5_nxxot")
 sfx_button_hover = ExtResource("5_ycj67")
 sfx_button_summon = ExtResource("6_5yvfi")
-sfx_combat_player_windup = ExtResource("7_g0wlx")

--- a/src/gameplay/Gameplay.tscn
+++ b/src/gameplay/Gameplay.tscn
@@ -69,10 +69,6 @@ grow_vertical = 0
 [node name="DeveloperOnlyNavigation" parent="CombatNodes" instance=ExtResource("3_6xc6h")]
 layout_mode = 1
 
-[node name="BackToStartMenuButton" parent="CombatNodes" instance=ExtResource("2_66iqr")]
-layout_direction = 0
-layout_mode = 1
-
 [node name="SummonNewHeroesButton" type="Button" parent="CombatNodes"]
 layout_mode = 1
 anchors_preset = -1
@@ -243,6 +239,10 @@ theme_override_constants/outline_size = 10
 theme_override_font_sizes/font_size = 48
 text = "Travelling..."
 horizontal_alignment = 1
+
+[node name="BackToStartMenuButton" parent="." instance=ExtResource("2_66iqr")]
+layout_direction = 0
+layout_mode = 1
 
 [connection signal="ready" from="." to="AudioManager" method="_on_gameplay_ready"]
 [connection signal="mouse_entered" from="CombatNodes/SummonNewHeroesButton" to="AudioManager" method="_on_summon_new_heroes_button_mouse_entered"]

--- a/src/start_menu/StartMenu.tscn
+++ b/src/start_menu/StartMenu.tscn
@@ -1,11 +1,10 @@
-[gd_scene load_steps=7 format=3 uid="uid://cckjypba5jdnl"]
+[gd_scene load_steps=6 format=3 uid="uid://cckjypba5jdnl"]
 
 [ext_resource type="Theme" uid="uid://c1rbyyhtqrqqt" path="res://assets/fonts/normal_font_theme.tres" id="1_toiww"]
 [ext_resource type="Theme" uid="uid://c76ovc86ky5qb" path="res://assets/fonts/start_menu_title_font_theme.tres" id="3_3syjn"]
 [ext_resource type="Theme" uid="uid://cio67ny2audx2" path="res://assets/fonts/start_menu_sub_title_font_theme.tres" id="4_0np53"]
 [ext_resource type="Script" path="res://src/start_menu/StartMenu.gd" id="5"]
 [ext_resource type="PackedScene" uid="uid://f34u2l70v1q7" path="res://src/audio_manager/AudioManager.tscn" id="5_oxss7"]
-[ext_resource type="AudioStream" uid="uid://65kxyr71uq6c" path="res://assets/audio/002_music_loop.ogg" id="6_akq6q"]
 
 [node name="StartMenu" type="Control"]
 layout_mode = 3
@@ -95,7 +94,6 @@ layout_mode = 2
 text = "Quit"
 
 [node name="AudioManager" parent="." instance=ExtResource("5_oxss7")]
-background_music_default = ExtResource("6_akq6q")
 
 [connection signal="ready" from="." to="AudioManager" method="_on_start_menu_ready"]
 [connection signal="mouse_entered" from="TitleControlsMarginContainer/Padding8px/TitleControlsRows/ButtonRows/StartButton" to="AudioManager" method="_on_start_button_mouse_entered"]


### PR DESCRIPTION
Allow escaping the game with the top-right corner 'X' button even while traveling.

**Purpose:** This change helps with testing in case the user did not exit fast enough to be before the traveling section. Normal users probably don't care as much since the first 2HP enemy is beaten in 1 hit.

**Minor Bug Fix:** Also fix SFX of heroes charging at the enemy, the SFX keeps getting the defaults overridden on accident.

## Screenshot

![2024-04-14_pr-allow-escape](https://github.com/SamBumgardner/alphabet-heroes/assets/11843918/148c8bf7-b120-460c-921e-ff446a4ffa49)
_**Screenshot 1:** Top-right X button is still shown and interactable while traveling during gameplay._